### PR TITLE
Redmine 3.3.3 compatibility

### DIFF
--- a/app/controllers/watcher_groups_controller.rb
+++ b/app/controllers/watcher_groups_controller.rb
@@ -66,7 +66,7 @@ class WatcherGroupsController < ApplicationController
   end
 
   def autocomplete_for_group
-    @groups = Group.active.like(params[:q]).find(:all, :limit => 100)
+    @groups = Group.sorted.active.like(params[:q]).limit(100)
     if @watched
       @groups -= @watched.watcher_groups
     end

--- a/lib/watcher_groups_issue_patch.rb
+++ b/lib/watcher_groups_issue_patch.rb
@@ -88,7 +88,7 @@ module WatcherGroupsIssuePatch
           if respond_to?(:visible?)
             group_users.reject! {|user| !visible?(user)}
           end
-          notified += group_users
+          notified |= group_users
       end
 
       notified += watcher_users.to_a
@@ -96,7 +96,7 @@ module WatcherGroupsIssuePatch
       if respond_to?(:visible?)
         notified.reject! {|user| !visible?(user)}
       end
-      notified.uniq
+      notified
     end
 
     def watched_by_with_groups?(user)
@@ -109,9 +109,9 @@ module WatcherGroupsIssuePatch
     def watcher_users_with_users
       users = watcher_users_without_users
       watcher_groups.each do |g|
-        users += g.users
+        users |= g.users
       end if self.id?
-      users.uniq
+      users
     end
   end
 end

--- a/lib/watcher_groups_issue_patch.rb
+++ b/lib/watcher_groups_issue_patch.rb
@@ -109,10 +109,12 @@ module WatcherGroupsIssuePatch
     def watcher_users_with_users
       users = watcher_users_without_users
       old_object = users
+      logger.info("WATCHER : Users before modification : #{old_object.class}")
       watcher_groups.each do |g|
         users |= g.users
       end if self.id?
-      users.define_singleton_method(:reset) do old_object.reset end
+      users.define_singleton_method(:reset) do old_object.reset end if old_object.class != users.class
+      logger.info("WATCHER : Users after modification : #{users.class}")
       users
     end
   end

--- a/lib/watcher_groups_issue_patch.rb
+++ b/lib/watcher_groups_issue_patch.rb
@@ -91,7 +91,7 @@ module WatcherGroupsIssuePatch
           notified |= group_users
       end
 
-      notified += watcher_users.to_a
+      notified |= watcher_users.to_a
       notified.reject! {|user| user.mail.blank? || user.mail_notification == 'none'}
       if respond_to?(:visible?)
         notified.reject! {|user| !visible?(user)}
@@ -108,9 +108,11 @@ module WatcherGroupsIssuePatch
 
     def watcher_users_with_users
       users = watcher_users_without_users
+      old_object = users
       watcher_groups.each do |g|
         users |= g.users
       end if self.id?
+      users.define_singleton_method(:reset) do old_object.reset end
       users
     end
   end

--- a/lib/watcher_groups_issue_patch.rb
+++ b/lib/watcher_groups_issue_patch.rb
@@ -109,12 +109,10 @@ module WatcherGroupsIssuePatch
     def watcher_users_with_users
       users = watcher_users_without_users
       old_object = users
-      logger.info("WATCHER : Users before modification : #{old_object.class}")
       watcher_groups.each do |g|
         users |= g.users
       end if self.id?
       users.define_singleton_method(:reset) do old_object.reset end if old_object.class != users.class
-      logger.info("WATCHER : Users after modification : #{users.class}")
       users
     end
   end


### PR DESCRIPTION
Fixed degradation of User::ActiveRecord_Associations_CollectionProxy into Array, makes it work on Redmine 3.3.3

users.uniq would degraded the complex structure into an Array, which can't receive the "reset" method, which Redmine core expects to be able to use.