### PR TITLE
Addition of settings flag for logging, added simple logging

### DIFF
--- a/app/views/settings/_redmine_watcher_groups_settings.html.erb
+++ b/app/views/settings/_redmine_watcher_groups_settings.html.erb
@@ -1,0 +1,10 @@
+<p>
+  <%= label_tag 'redmine_watcher_groups_log_watchers_setting', l(:label_watcher_change_setlog) %>
+  <%=
+    select_tag 'settings[redmine_watcher_groups_log_watchers_setting]', options_for_select([
+      [l(:general_text_No), 'no'],
+      [l(:general_text_Yes), 'yes'],
+    ], @settings['redmine_watcher_groups_log_watchers_setting'])  %>
+   <%=l(:label_authorchange_setlog_description) %>
+</p>
+

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,5 @@
-# English strings go here for Rails i18n
-en:
+# Czech strings go here for Rails i18n
+cs:
   my_label: "My label"
   label_issue_watcher_groups: "Sledováno skupinami"
   label_group_search: "Vyhledání skupiny:"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,4 @@
 # English strings go here for Rails i18n
-en:
-  my_label: "My label"
+cs:
   label_issue_watcher_groups: "Sledováno skupinami"
   label_group_search: "Vyhledání skupiny:"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,5 @@
+# German strings go here for Rails i18n
+de:
+  my_label: "Meine Kennung"
+  label_issue_watcher_groups: "Beobachtergruppen"
+  label_group_search: "Suche nach Gruppe:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,9 @@
 # English strings go here for Rails i18n
 en:
-  my_label: "My label"
   label_issue_watcher_groups: "Watcher Groups"
   label_group_search: "Search for group:"
+  label_watcher_user_add: "'%{name}' added user(s) '%{target_name}' to watchers"
+  label_watcher_user_remove: "'%{name}' removed user(s) '%{target_name}' from watchers"
+  label_watcher_group_add: "'%{name}' added group(s) '%{target_name}' to watchers"
+  label_watcher_group_remove: "'%{name}' removed group(s) '%{target_name}' from watchers"
+  label_watcher_change_setlog: "Log in issue history? "

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,3 @@
 it:
-  my_label: "Etichetta"
   label_issue_watcher_groups: "Gruppi osservatori"
   label_group_search: "Cerca un gruppo:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,9 @@
 # Japanese strings go here for Rails i18n
 ja:
-  my_label: "My label"
   label_issue_watcher_groups: "ウォッチャーグループ"
   label_group_search: "グループの検索:"
+  label_watcher_user_add: "「%{name}」がユーザ「%{target_name}」をウォッチャーに追加しました"
+  label_watcher_user_remove: "「%{name}」がユーザ「%{target_name}」をウォッチャーから外しました"
+  label_watcher_group_add: "「%{name}」がグループ「%{target_name}」をウォッチャーに追加しました"
+  label_watcher_group_remove: "「%{name}」がグループ「%{target_name}」をウォッチャーから外しました"
+  label_watcher_change_setlog: "チケット履歴に記録しますか？ "

--- a/init.rb
+++ b/init.rb
@@ -16,13 +16,19 @@ Rails.configuration.to_prepare do
     IssuesController.send(:include, WatcherGroupsIssuesControllerPatch)
   end
 
+  unless WatchersController.included_modules.include?(WatcherGroupsWatchersControllerPatch)
+    WatchersController.send(:include, WatcherGroupsWatchersControllerPatch)
+  end
+
 end
 
 Redmine::Plugin.register :redmine_watcher_groups do
   name 'Redmine Watcher Groups plugin'
-  author 'Kamen Ferdinandov, Massimo Rossello'
+  author 'Kamen Ferdinandov, Massimo Rossello, Stephane Lapie'
   description 'This is a plugin for Redmine to add watcher groups functionality'
   version '1.0.0'
   url 'http://github.com/maxrossello/redmine_watcher_groups'
   author_url 'http://github.com/maxrossello'
+
+  settings :default => {"redmine_watcher_groups_log_watchers_setting" => 'no'}, :partial => 'settings/redmine_watcher_groups_settings'
 end

--- a/lib/watcher_groups_issue_hook.rb
+++ b/lib/watcher_groups_issue_hook.rb
@@ -12,17 +12,21 @@ module WatcherGroupsIssueHooks
         context[:issue].save
         context[:issue].reload
 
-        notes = []
-        group_ids = context[:params][:issue]["watcher_group_ids"]
-        group_ids.each do |group_id|
-          group_users = Group.find(group_id.to_i).users.uniq
-          group_users.each do |user|
-            notes.append("Watcher #{user.name} was added")
-          end
-        end
-
-        if notes.any? and Redmine::Plugin.installed? :redmine_advanced_issue_history
-          add_system_journal(notes, context[:issue])
+	if Setting['plugin_redmine_watcher_groups']['redmine_watcher_groups_log_watchers_setting'] == 'yes'
+	  group_ids = context[:params][:issue]["watcher_group_ids"]
+	  if Redmine::Plugin.installed? :redmine_advanced_issue_history
+	    notes = []
+            group_ids.each do |group_id|
+	      group_users = Group.find(group_id.to_i).users.uniq
+	      group_users.each do |user|
+		notes.append("Watcher #{user.name} was added")
+	      end
+	    end
+	    add_system_journal(notes, context[:issue]) if notes.any?
+	  else
+	    watcher_name = group_ids.collect { |group_id| Group.find(group_id).name }.join(", ")
+	    context[:issue].add_watcher_journal(:label_watcher_group_add, watcher_name)
+	  end
         end
       end
 

--- a/lib/watcher_groups_watchers_controller_patch.rb
+++ b/lib/watcher_groups_watchers_controller_patch.rb
@@ -1,0 +1,26 @@
+module WatcherGroupsWatchersControllerPatch
+    def self.included(base) # :nodoc:
+	base.send(:include, InstanceMethods)
+	base.class_eval do
+	    alias_method_chain :create, :journal
+	end
+    end
+
+    WatchersController.class_eval do
+        module InstanceMethods
+	    def create_with_journal
+	        create_without_journal
+		user_ids = []
+		if params[:watcher].is_a?(Hash)
+		    user_ids << (params[:watcher][:user_ids] || params[:watcher][:user_id])
+		else
+		    user_ids << params[:user_id]
+		end
+		@watchables.each do |watched|
+		    watched.add_watcher_journal(:label_watcher_user_add, user_ids.flatten.compact.uniq.collect { |user_id| User.find(user_id).name }.join(", "))
+		end
+	    end
+	end
+    end
+end
+


### PR DESCRIPTION
My modification allows for setting up whether you want watcher group/users changes recorded or not, and if redmine_advanced_issue_history is not present, it will then create a user comment in the name of the person who added/removed watchers.

This is used in our company to ensure no one removes/adds watchers without everyone knowing. This has also the nice effect of making it simple to send an e-mail notification to someone you want to see the ticket and hopefully do something about it.

It also includes deining's commits for German and Czech.